### PR TITLE
Added resampy dependency

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,1 +1,2 @@
 nemo_toolkit[asr]
+resampy


### PR DESCRIPTION
# Description
Starting from `librosa==0.10.0` resampy isn't installed by default
Only using lazy install, so we forcing it to install
More details [here](https://github.com/librosa/librosa/pull/1579)