### PR TITLE
ONNX runtime for Nemo models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__
 .vscode
+build
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
 .vscode
 build
+dist
 *.egg-info

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,5 +4,6 @@ onnxruntime
 sentencepiece
 # resampling
 soxr
+pydub
 # huggingface
 huggingface-hub

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,8 @@
-nemo_toolkit[asr]
+# model
+torch
+onnxruntime
+sentencepiece
+# resampling
 resampy
+# huggingface
+huggingface-hub

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,6 +3,6 @@ torch
 onnxruntime
 sentencepiece
 # resampling
-resampy
+soxr
 # huggingface
 huggingface-hub

--- a/streaming_stt_nemo/__init__.py
+++ b/streaming_stt_nemo/__init__.py
@@ -1,5 +1,6 @@
 import numpy as np
 import soxr
+from pydub import AudioSegment
 
 import ctypes, gc
 
@@ -84,6 +85,19 @@ class Model:
         self._trim_memory()
         return current_hypotheses
     
+    def stt_file(self, file_path: str):
+        audio_buffer, sr = self.read_file(file_path)
+        current_hypotheses = self.stt(audio_buffer, sr)
+        return current_hypotheses
+
+    def read_file(self, file_path: str):
+        audio_file = AudioSegment.from_file(file_path)
+        sr = audio_file.frame_rate
+
+        samples = audio_file.get_array_of_samples()
+        audio_buffer = np.array(samples)
+        return audio_buffer, sr
+
     @staticmethod
     def _trim_memory():
         """

--- a/streaming_stt_nemo/__init__.py
+++ b/streaming_stt_nemo/__init__.py
@@ -13,6 +13,10 @@ from huggingface_hub import hf_hub_download
 from .configs import languages, sample_rate, subfolder_name
 
 
+
+available_languages = list(languages.keys())
+
+
 class Model:
     langs = languages
     sample_rate = sample_rate
@@ -116,3 +120,8 @@ class Model:
     def _to_float32(self, audio_buffer: np.array):
         audio_fp32 = np.divide(audio_buffer, np.iinfo(audio_buffer.dtype).max, dtype=np.float32)
         return audio_fp32
+
+
+
+
+__all__ = ["Model", "available_languages"]

--- a/streaming_stt_nemo/__init__.py
+++ b/streaming_stt_nemo/__init__.py
@@ -41,8 +41,10 @@ class Model:
         self.tokenizer = spm.SentencePieceProcessor(tokenizer_path)
 
     def _run_preprocessor(self, audio_16k: np.array):
+        input_signal = torch.tensor(audio_16k).unsqueeze(0)
+        length = torch.tensor(len(audio_16k)).unsqueeze(0)
         processed_signal, processed_signal_len = self.preprocessor.forward(
-            input_signal = torch.tensor([audio_16k]), length = torch.tensor([len(audio_16k)])
+            input_signal = input_signal, length = length
         )
         processed_signal = processed_signal.numpy()
         processed_signal_len = processed_signal_len.numpy()

--- a/streaming_stt_nemo/__init__.py
+++ b/streaming_stt_nemo/__init__.py
@@ -1,48 +1,90 @@
 import numpy as np
 import resampy
+
+import ctypes, gc
+
 import torch
+import sentencepiece as spm
+import onnxruntime as ort
 
-from nemo.collections.asr.models import EncDecCTCModelBPE
+from huggingface_hub import hf_hub_download
 
-from .configs import languages
+from .configs import languages, sample_rate, subfolder_name
 
 
 class Model:
     langs = languages
+    sample_rate = sample_rate
 
 
     def __init__(self, lang="en"):
-        self.stt_model = EncDecCTCModelBPE. \
-                    from_pretrained(self.langs[lang]["model"], map_location="cpu")
-        self.freeze_model()
+        self._init_model(lang)
         
+    def _init_model(self, lang: str):
+        model_name = self.langs[lang]["model"]
+        self._init_preprocessor(model_name)
+        self._init_encoder(model_name)
+        self._init_tokenizer(model_name)
 
-    def freeze_model(self):
-        self.stt_model.preprocessor.featurizer.dither = 0.0
-        self.stt_model.preprocessor.featurizer.pad_to = 0
-        # Switch model to evaluation mode
-        self.stt_model.eval()
-        # Freeze the encoder and decoder modules
-        self.stt_model.encoder.freeze()
-        self.stt_model.decoder.freeze()
+    def _init_preprocessor(self, model_name: str):
+        preprocessor_path = hf_hub_download(model_name, "preprocessor.ts", subfolder=subfolder_name)
+        self.preprocessor = torch.jit.load(preprocessor_path)
+
+    def _init_encoder(self, model_name: str):
+        encoder_path = hf_hub_download(model_name, "model.onnx", subfolder=subfolder_name)
+        self.encoder = ort.InferenceSession(encoder_path)
+
+    def _init_tokenizer(self, model_name: str):
+        tokenizer_path = hf_hub_download(model_name, "tokenizer.spm", subfolder=subfolder_name)
+        self.tokenizer = spm.SentencePieceProcessor(tokenizer_path)
+
+    def _run_preprocessor(self, audio_16k: np.array):
+        processed_signal, processed_signal_len = self.preprocessor.forward(
+            input_signal = torch.tensor([audio_16k]), length = torch.tensor([len(audio_16k)])
+        )
+        processed_signal = processed_signal.numpy()
+        processed_signal_len = processed_signal_len.numpy()
+        return processed_signal, processed_signal_len
+
+    def _run_encoder(self, processed_signal: np.array, processed_signal_len: np.array):
+        outputs = self.encoder.run(None, {'audio_signal': processed_signal,
+                              'length':processed_signal_len})
+        logits = outputs[0][0]
+        return logits
+
+    def _run_tokenizer(self, logits: np.array):
+        blank_id = self.tokenizer.vocab_size()
+        decoded_prediction = self._ctc_decode(logits, blank_id)
+        text = self.tokenizer.decode_ids(decoded_prediction)
+        current_hypotheses = [text]
+        return current_hypotheses
+
+    @staticmethod
+    def _ctc_decode(logits: np.array, blank_id: int):
+        labels = logits.argmax(axis=1).tolist()
+
+        previous = blank_id
+        decoded_prediction = []
+        for p in labels:
+            if (p != previous or previous == blank_id) and p != blank_id:
+                decoded_prediction.append(p)
+            previous = p
+        return decoded_prediction
+        
 
     def stt(self, audio_buffer: np.array, sr: int):
         audio_fp32 = self._to_float32(audio_buffer)
         audio_16k = self._resample(audio_fp32, sr)
 
-        logits, logits_len, greedy_predictions = self.stt_model.forward(
-            input_signal=torch.tensor([audio_16k]), 
-            input_signal_length=torch.tensor([len(audio_16k)])
-        )
+        processed_signal, processed_signal_len = self._run_preprocessor(audio_16k)
+        logits = self._run_encoder(processed_signal, processed_signal_len)
+        current_hypotheses = self._run_tokenizer(logits)
 
-        current_hypotheses, all_hyp = self.stt_model.decoding.ctc_decoder_predictions_tensor(
-            logits, decoder_lengths=logits_len, return_hypotheses=False,
-        )
         return current_hypotheses
-
+    
 
     def _resample(self, audio_fp32: np.array, sr: int):
-        audio_16k = resampy.resample(audio_fp32, sr, self.stt_model.cfg.sample_rate)
+        audio_16k = resampy.resample(audio_fp32, sr, self.sample_rate)
         return audio_16k
 
 

--- a/streaming_stt_nemo/__init__.py
+++ b/streaming_stt_nemo/__init__.py
@@ -1,5 +1,5 @@
 import numpy as np
-import resampy
+import soxr
 
 import ctypes, gc
 
@@ -94,7 +94,7 @@ class Model:
         gc.collect()
 
     def _resample(self, audio_fp32: np.array, sr: int):
-        audio_16k = resampy.resample(audio_fp32, sr, self.sample_rate)
+        audio_16k = soxr.resample(audio_fp32, sr, self.sample_rate)
         return audio_16k
 
     def _to_float32(self, audio_buffer: np.array):

--- a/streaming_stt_nemo/configs.py
+++ b/streaming_stt_nemo/configs.py
@@ -56,3 +56,9 @@ languages = {
         "model": "neongeckocom/stt_ca_citrinet_512_gamma_0_25", 
     },
 }
+
+
+sample_rate = 16000
+
+
+subfolder_name = "onnx"


### PR DESCRIPTION
## Description
- Shift from `pytorch` to `onnx` runtime for `nemo` models (x2 faster for Rpi4)
- Replacing `resampy` with `soxr` as x10 [faster](https://github.com/dofuuz/python-soxr#speed-comparison-summary) 
- Using torchscript preprocessor, waiting for onnx [here](https://github.com/NVIDIA/NeMo/pull/5512)
- Dependencies list reduced to onnx, torch, sentencepiece
- Added `available_languages` importable variable

## Other Notes
No breaking changes